### PR TITLE
Allow customization of IServiceProvider

### DIFF
--- a/samples/SampleConsoleApp/Program.cs
+++ b/samples/SampleConsoleApp/Program.cs
@@ -5,6 +5,7 @@ using System;
 using System.CommandLine.Invocation;
 using System.Diagnostics;
 using System.Threading.Tasks;
+using Microsoft.Extensions.Hosting;
 using SampleConsoleApp.Middleware;
 using Upstream.CommandLine;
 
@@ -37,7 +38,11 @@ namespace SampleConsoleApp
 
         public static CommandLineApplication BuildCommandLineApplication()
         {
-            return new CommandLineApplication()
+            var hostBuilder = Host.CreateDefaultBuilder()
+                // Use a custom factory here to integrate other DI libraries like Autofac
+                .UseServiceProviderFactory(new DefaultServiceProviderFactory());
+
+            return new CommandLineApplication(hostBuilder)
                 .AddCommand<FooCommandHandler, FooCommand>()
                 .AddCommand<BarCommandHandler, BarCommand>("bar")
                 .AddCommandGroup("gizmo", builder =>

--- a/src/Upstream.CommandLine/CommandBuilder.cs
+++ b/src/Upstream.CommandLine/CommandBuilder.cs
@@ -47,10 +47,9 @@ namespace Upstream.CommandLine
             "Command was invoked without building ServiceProvider");
 
         [MemberNotNull(nameof(_serviceProvider))]
-        internal Parser Build()
+        internal Parser Build(IServiceProvider provider)
         {
-            _serviceProvider = _services.BuildServiceProvider();
-
+            _serviceProvider = provider;
             return CommandLineBuilder.Build();
         }
 
@@ -142,7 +141,7 @@ namespace Upstream.CommandLine
             {
                 return; // no need to add to command stack
             }
-            
+
             _commandStack.Push(command);
 
             builderAction.Invoke();

--- a/test/Upstream.CommandLine.Test/CommandLineApplicationTests.cs
+++ b/test/Upstream.CommandLine.Test/CommandLineApplicationTests.cs
@@ -1,9 +1,10 @@
 ﻿using System;
 using System.Threading;
 using System.Threading.Tasks;
+using FluentAssertions;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
 using Moq;
-using NuGet.Frameworks;
 using Upstream.Testing;
 using Xunit;
 
@@ -31,15 +32,45 @@ public class CommandLineApplicationTests : TestBase<CommandLineApplication>
         });
 
         _ = TestClass.Build();
-        
+
         Assert.NotNull(TestClass.ServiceProvider);
 
         var foo1 = TestClass.ServiceProvider.GetRequiredService<FooCommand>();
         var foo2 = TestClass.ServiceProvider.GetRequiredService<FooCommand>();
-        
+
         Assert.NotNull(foo1);
         Assert.NotNull(foo2);
         Assert.Same(foo1, foo2);
+    }
+
+    [Fact]
+    public void Configure_services_is_additive()
+    {
+        TestClass.ConfigureServices(services => services.AddScoped<FooCommand>());
+        TestClass.ConfigureServices(services => services.AddScoped<BarCommand>());
+        _ = TestClass.Build();
+
+        var act = () =>
+        {
+            TestClass.ServiceProvider.GetRequiredService<FooCommand>();
+            TestClass.ServiceProvider.GetRequiredService<BarCommand>();
+        };
+
+        act.Should().NotThrow();
+    }
+
+    [Fact]
+    public void Host_builder_is_configurable()
+    {
+        var hostBuilder = Host.CreateDefaultBuilder()
+            .ConfigureServices(s => s.AddScoped<FooCommand>());
+        var cliApp = new CommandLineApplication(hostBuilder);
+
+        cliApp.Build();
+
+        var act = () => cliApp.ServiceProvider.GetService<FooCommand>();
+
+        act.Should().NotThrow();
     }
 
     [Fact]
@@ -55,22 +86,22 @@ public class CommandLineApplicationTests : TestBase<CommandLineApplication>
             });
 
         var exitCode = await TestClass.InvokeAsync(new[] { "foo" });
-        
+
         Assert.Equal(0, exitCode);
-        
+
         outputMock.VerifyAll();
     }
-    
+
     public interface IOutput
     {
         void Write(string value);
     }
-    
+
     [Command("foo", "Foo is Bar")]
     private class FooCommand
     {
     }
-    
+
     private class FooCommandHandler : ICommandHandler<FooCommand>
     {
         private readonly IOutput _output;
@@ -88,5 +119,10 @@ public class CommandLineApplicationTests : TestBase<CommandLineApplication>
 
             return Task.FromResult(0);
         }
+    }
+
+    [Command("bar", "Bar is Foo")]
+    private class BarCommand
+    {
     }
 }


### PR DESCRIPTION
In order to integrate custom DI container such as Autofac, one needs to be able to customize creation of the `IServiceProvider` instance.

A new extension method named `WithServiceProvider()` has been created for `CommandLineApplication` that allows optional customization of how the `IServiceProvider` instance is created.

See the example below which integrates `Autofac`:

```cs
return new CommandLineApplication()
    .WithServiceProvider(serviceCollection =>
    {
        var builder = new ContainerBuilder();
        CompositionRoot.Setup(builder);
        builder.Populate(serviceCollection);
        return new AutofacServiceProvider(builder.Build());
    })
```

Where `CompositionRoot.Setup()` sets up registrations in the Autofac container.