### PR TITLE
Upgrade to beta-4 of System.CommandLine

### DIFF
--- a/src/Upstream.CommandLine/Upstream.CommandLine.csproj
+++ b/src/Upstream.CommandLine/Upstream.CommandLine.csproj
@@ -23,8 +23,8 @@
 
     <ItemGroup>
         <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="6.0.0" />
-        <PackageReference Include="System.CommandLine" Version="2.0.0-beta3.22114.1" />
-        <PackageReference Include="System.CommandLine.Hosting" Version="0.4.0-alpha.22114.1" />
+        <PackageReference Include="System.CommandLine" Version="2.0.0-beta4.22272.1" />
+        <PackageReference Include="System.CommandLine.NamingConventionBinder" Version="2.0.0-beta4.22272.1" />
     </ItemGroup>
     
     <ItemGroup>

--- a/test/Upstream.CommandLine.Test/CommandLineApplicationTests.cs
+++ b/test/Upstream.CommandLine.Test/CommandLineApplicationTests.cs
@@ -3,7 +3,6 @@ using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Extensions.DependencyInjection;
 using Moq;
-using NuGet.Frameworks;
 using Upstream.Testing;
 using Xunit;
 


### PR DESCRIPTION
- Upgrade `System.CommandLine` to version `2.0.0-beta4.22272.1`
- Use Activator to instantiate `Argument<>` and `Option<>`

Addresses #16.